### PR TITLE
feat(deploy): add Railway deployment for the full stack

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -22,7 +22,14 @@ RUN npm run build
 
 FROM ${NGINX_IMAGE} AS runtime
 
-COPY nginx.frontend.conf /etc/nginx/conf.d/default.conf
+# Rendered at start: 10-...envsh computes port/upstreams/resolver, then the
+# stock 20-envsubst-on-templates.sh expands the ${RSTMANAGER_*} placeholders.
+# The filter keeps envsubst from touching nginx's own $variables.
+ENV NGINX_ENVSUBST_FILTER="^RSTMANAGER_"
+COPY nginx.frontend.conf.template /etc/nginx/templates/default.conf.template
+COPY docker/nginx/10-rstmanager-resolver.envsh /docker-entrypoint.d/10-rstmanager-resolver.envsh
+RUN chmod +x /docker-entrypoint.d/10-rstmanager-resolver.envsh
 COPY --from=build /app/dist /usr/share/nginx/html
 
+# Informational only; the real listen port comes from $PORT (Railway) or 80.
 EXPOSE 80

--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -1,0 +1,16 @@
+ARG KEYCLOAK_IMAGE=quay.io/keycloak/keycloak:26.3
+
+FROM ${KEYCLOAK_IMAGE}
+
+# The realm is baked into the image (Railway has no bind mounts). It lives in a
+# template dir; the entrypoint rewrites the public origin into the import dir at
+# start, so the same image serves any domain via RSTMANAGER_PUBLIC_APP_URL.
+COPY keycloak/rstmanager-realm.json /opt/keycloak/data/import-template/rstmanager-realm.json
+COPY docker/keycloak/entrypoint.sh /opt/keycloak/rstmanager-entrypoint.sh
+
+USER root
+RUN chmod +x /opt/keycloak/rstmanager-entrypoint.sh
+USER 1000
+
+ENTRYPOINT ["/opt/keycloak/rstmanager-entrypoint.sh"]
+CMD ["start", "--import-realm"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Navigate to http://localhost:3333
 
 Open the browser's dev console – this is where logs and exceptions will go.
 
+## Deploy
+
+To deploy the full stack on [Railway](https://railway.com) (managed Postgres +
+three services behind a single public frontend domain), see
+[`docs/DEPLOY-railway.md`](docs/DEPLOY-railway.md).
+
 ## Application with Docker Compose
 
 The full stack can be started with Compose: Postgres, the Scala backend API, and the Scala.js/Vite frontend served by nginx:

--- a/docker/keycloak/entrypoint.sh
+++ b/docker/keycloak/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Renders the realm import file for the target public origin, then hands off to
+# Keycloak. The committed realm (keycloak/rstmanager-realm.json) hardcodes the
+# local-dev origin http://localhost:3333 in the client's rootUrl / redirectUris /
+# webOrigins / post-logout URIs; here we rewrite that single origin to whatever
+# the deployment exposes (RSTMANAGER_PUBLIC_APP_URL). Uses only bash builtins so
+# no extra tooling (envsubst/sed) needs to be present in the Keycloak image.
+set -euo pipefail
+
+: "${RSTMANAGER_PUBLIC_APP_URL:=http://localhost:3333}"
+
+src="/opt/keycloak/data/import-template/rstmanager-realm.json"
+dst_dir="/opt/keycloak/data/import"
+dst="${dst_dir}/rstmanager-realm.json"
+
+mkdir -p "${dst_dir}"
+content="$(cat "${src}")"
+content="${content//http:\/\/localhost:3333/${RSTMANAGER_PUBLIC_APP_URL}}"
+printf '%s\n' "${content}" > "${dst}"
+
+echo "[rstmanager] realm import rendered for origin: ${RSTMANAGER_PUBLIC_APP_URL}"
+
+exec /opt/keycloak/bin/kc.sh "$@"

--- a/docker/nginx/10-rstmanager-resolver.envsh
+++ b/docker/nginx/10-rstmanager-resolver.envsh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Sourced by the nginx image entrypoint (*.envsh) BEFORE 20-envsubst-on-templates.sh.
+# Populates the ${RSTMANAGER_*} placeholders used by default.conf.template so the
+# same image works both under docker compose (Docker embedded DNS, IPv4) and on
+# Railway (private networking, IPv6-only *.railway.internal names).
+
+# Public listen port: Railway injects $PORT; compose leaves it unset -> 80.
+export RSTMANAGER_NGINX_PORT="${RSTMANAGER_NGINX_PORT:-${PORT:-80}}"
+
+# Upstreams. Compose defaults use the compose service names; on Railway these
+# MUST be overridden with the fully-qualified private names, e.g.
+#   RSTMANAGER_API_UPSTREAM=planning-service.railway.internal:8080
+#   RSTMANAGER_KC_UPSTREAM=keycloak.railway.internal:8080
+export RSTMANAGER_API_UPSTREAM="${RSTMANAGER_API_UPSTREAM:-planning-service:8080}"
+export RSTMANAGER_KC_UPSTREAM="${RSTMANAGER_KC_UPSTREAM:-keycloak:8080}"
+
+# Derive the DNS resolver from the container's /etc/resolv.conf. Docker's
+# embedded DNS is 127.0.0.11 (IPv4); Railway's private resolver is IPv6. nginx
+# needs IPv6 nameservers bracketed and must NOT disable ipv6 lookups there, or
+# the AAAA-only *.railway.internal names never resolve.
+ns="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null)"
+[ -n "$ns" ] || ns="127.0.0.11"
+case "$ns" in
+  *:*)
+    export RSTMANAGER_NGINX_RESOLVER="[$ns]"
+    export RSTMANAGER_NGINX_RESOLVER_IPV6="ipv6=on"
+    ;;
+  *)
+    export RSTMANAGER_NGINX_RESOLVER="$ns"
+    export RSTMANAGER_NGINX_RESOLVER_IPV6="ipv6=off"
+    ;;
+esac

--- a/docs/DEPLOY-railway.md
+++ b/docs/DEPLOY-railway.md
@@ -1,0 +1,206 @@
+# Deploy su Railway
+
+Guida per portare rstmanager su [Railway](https://railway.com). Lo stack
+`docker-compose` non si trasferisce così com'è: Railway deploya **un servizio per
+immagine** e i servizi si parlano via **private networking solo IPv6**
+(`<nome>.railway.internal`). Il design same-origin dell'app (nginx unico
+entrypoint che proxa `/api`, `/auth`, `/docs`) è però ideale per Railway e viene
+preservato.
+
+## Topologia
+
+Un progetto Railway con quattro servizi, **un solo dominio pubblico** (il
+frontend); backend e Keycloak restano privati.
+
+```
+                Internet (HTTPS, TLS all'edge Railway)
+                              │
+                     ┌────────▼─────────┐   dominio pubblico
+                     │  frontend (nginx)│   es. rstmanager.up.railway.app
+                     │  Dockerfile.frontend
+                     └───┬───────────┬──┘
+          /api  /docs    │           │   /auth
+     (IPv6 privato)      │           │  (IPv6 privato)
+            ┌────────────▼──┐   ┌────▼──────────────┐
+            │ planning-     │   │ keycloak          │
+            │ service       │   │ Dockerfile.keycloak
+            │ Dockerfile.   │   └────┬──────────────┘
+            │ service       │        │
+            └──────┬────────┘        │
+                   │  (IPv6 privato) │
+              ┌────▼─────────────────▼────┐
+              │  Postgres (plugin managed)│
+              │  db "railway" + db "keycloak"
+              └───────────────────────────┘
+```
+
+## ⚠️ I due vincoli Railway che rompono tutto se ignorati
+
+1. **Private networking è solo IPv6.** Un processo che ascolta solo su
+   `0.0.0.0` (IPv4) **non riceve** traffico privato. Backend e Keycloak devono
+   bindare `::` (vedi `RSTMANAGER_HTTP_HOST=::` e `KC_HTTP_HOST=::` sotto). Sulla
+   JVM `::` è dual-stack, quindi accetta anche IPv4 — nessun altro effetto.
+2. **Gli upstream nginx devono usare il nome privato completo**
+   `*.railway.internal`, non il nome corto. Per questo sul servizio frontend si
+   impostano `RSTMANAGER_API_UPSTREAM` e `RSTMANAGER_KC_UPSTREAM` con il suffisso
+   `.railway.internal` (i default corti valgono solo per docker compose).
+
+> **Naming dei servizi:** chiama i servizi Railway **`planning-service`**,
+> **`keycloak`** e **`frontend`**. I valori degli upstream e degli URL interni
+> qui sotto assumono questi nomi. Se usi nomi diversi, adegua di conseguenza gli
+> hostname `.railway.internal`.
+
+## Cosa c'è già nel repo
+
+| File | Ruolo |
+|------|-------|
+| `Dockerfile.service` | Immagine backend (invariata) |
+| `Dockerfile.frontend` | Immagine nginx; il conf viene reso da template all'avvio |
+| `Dockerfile.keycloak` | Keycloak + realm bakato, origin riscritto all'avvio |
+| `nginx.frontend.conf.template` | Conf nginx parametrizzato (porta/upstream/resolver) |
+| `docker/nginx/10-rstmanager-resolver.envsh` | Calcola resolver IPv6/IPv4 e default |
+| `docker/keycloak/entrypoint.sh` | Riscrive l'origin pubblico nel realm import |
+| `railway.service.json` / `railway.frontend.json` / `railway.keycloak.json` | Config-as-code per servizio |
+
+Nessuna modifica al codice Scala: il frontend è già same-origin
+(`window.location.origin + "/auth"`, `baseUrl = "/api/v1"`) e il backend legge
+host/porta DB e config Keycloak da env.
+
+## Procedura passo-passo
+
+### 1. Progetto + Postgres
+
+1. Crea un nuovo progetto Railway (consigliato: collegalo a questo repo GitHub).
+2. **New → Database → Add PostgreSQL.** Rinomina il servizio `Postgres`.
+
+### 2. Crea il database `keycloak` nella stessa istanza Postgres
+
+Il plugin espone un solo database (`railway`); il tuo init-script locale non
+gira su Railway. Crea a mano DB e utente per Keycloak, una tantum. Con la CLI:
+
+```bash
+railway link         # seleziona il progetto
+railway connect Postgres   # apre psql sull'istanza
+```
+
+poi in psql:
+
+```sql
+CREATE USER keycloak WITH PASSWORD '<scegli-una-password>';
+CREATE DATABASE keycloak OWNER keycloak;
+```
+
+(In alternativa: tab **Data** del servizio Postgres → Query.)
+
+### 3. Servizio `frontend` e dominio pubblico
+
+Crealo per primo così ottieni subito il dominio a cui puntano Keycloak e il
+backend.
+
+1. **New → GitHub Repo** (lo stesso repo) → nome servizio `frontend`.
+2. **Settings → Config-as-code** → path `railway.frontend.json`.
+3. **Settings → Networking → Generate Domain.** Annota l'URL, es.
+   `https://rstmanager-frontend-production.up.railway.app`. Chiamiamolo
+   **`<APP_URL>`**. Il suo path auth è **`<APP_URL>/auth`** = **`<AUTH_URL>`**.
+4. Variabili (le patchi tra poco quando i nomi interni esistono):
+
+   | Variabile | Valore |
+   |-----------|--------|
+   | `RSTMANAGER_API_UPSTREAM` | `planning-service.railway.internal:8080` |
+   | `RSTMANAGER_KC_UPSTREAM` | `keycloak.railway.internal:8080` |
+
+   Il primo deploy fallirà l'health finché il backend non è su: è atteso.
+
+### 4. Servizio `keycloak`
+
+1. **New → GitHub Repo** → nome `keycloak`.
+2. **Settings → Config-as-code** → `railway.keycloak.json`.
+3. Variabili:
+
+   | Variabile | Valore |
+   |-----------|--------|
+   | `KC_DB` | `postgres` |
+   | `KC_DB_URL` | `jdbc:postgresql://${{Postgres.PGHOST}}:${{Postgres.PGPORT}}/keycloak` |
+   | `KC_DB_USERNAME` | `keycloak` |
+   | `KC_DB_PASSWORD` | la password scelta al passo 2 |
+   | `KC_HTTP_ENABLED` | `true` |
+   | `KC_HTTP_HOST` | `::` &nbsp;← **bind IPv6 per il private networking** |
+   | `KC_HTTP_PORT` | `8080` |
+   | `KC_HTTP_RELATIVE_PATH` | `/auth` |
+   | `KC_HOSTNAME` | `<AUTH_URL>` &nbsp;(es. `https://…up.railway.app/auth`) |
+   | `KC_PROXY_HEADERS` | `xforwarded` |
+   | `KC_HEALTH_ENABLED` | `true` |
+   | `KC_BOOTSTRAP_ADMIN_USERNAME` | scegli (non `admin` in prod) |
+   | `KC_BOOTSTRAP_ADMIN_PASSWORD` | scegli una password robusta |
+   | `RSTMANAGER_PUBLIC_APP_URL` | `<APP_URL>` &nbsp;(senza `/auth`) |
+
+   `RSTMANAGER_PUBLIC_APP_URL` è ciò con cui l'entrypoint riscrive redirect URIs
+   / webOrigins del client nel realm importato. **Non** dare un dominio pubblico
+   a questo servizio: resta privato.
+
+### 5. Servizio `planning-service`
+
+1. **New → GitHub Repo** → nome `planning-service`.
+2. **Settings → Config-as-code** → `railway.service.json`.
+3. Variabili:
+
+   | Variabile | Valore |
+   |-----------|--------|
+   | `RSTMANAGER_HTTP_HOST` | `::` &nbsp;← **bind IPv6 per il private networking** |
+   | `RSTMANAGER_HTTP_PORT` | `8080` |
+   | `RSTMANAGER_DB_HOST` | `${{Postgres.PGHOST}}` |
+   | `RSTMANAGER_DB_PORT` | `${{Postgres.PGPORT}}` |
+   | `RSTMANAGER_DB_NAME` | `${{Postgres.PGDATABASE}}` |
+   | `RSTMANAGER_DB_USER` | `${{Postgres.PGUSER}}` |
+   | `RSTMANAGER_DB_PASSWORD` | `${{Postgres.PGPASSWORD}}` |
+   | `RSTMANAGER_DB_POOL_SIZE` | `4` |
+   | `RSTMANAGER_KEYCLOAK_INTERNAL_URL` | `http://keycloak.railway.internal:8080/auth` |
+   | `RSTMANAGER_KEYCLOAK_REALM` | `rstmanager` |
+   | `RSTMANAGER_KEYCLOAK_ISSUER` | `<AUTH_URL>/realms/rstmanager` |
+   | `RSTMANAGER_KEYCLOAK_CLIENT_ID` | `rstmanager-frontend` |
+
+   Il backend fetcha le JWKS dall'URL **interno** ma valida l'issuer **esterno**
+   (`<AUTH_URL>/realms/rstmanager`): devono combaciare esattamente col dominio
+   pubblico del frontend, altrimenti tutti 401.
+
+### 6. Ordine di avvio e redeploy
+
+1. Verifica che `Postgres` sia up e che il DB `keycloak` esista (passo 2).
+2. Deploya/redeploya `keycloak` → attendi che i log mostrino
+   `Listening on: http://[::]:8080` e l'import del realm.
+3. Deploya/redeploya `planning-service` → health `/api/v1/health` verde.
+4. Redeploya `frontend` → health `/` verde.
+
+### 7. Utenti e ruoli
+
+Il realm non contiene utenti. Vai su `<APP_URL>/auth/admin`, login con le
+credenziali bootstrap, crea gli utenti e assegna i realm role `viewer` /
+`operator` / `admin` (gerarchici — vedi `README.md`).
+
+## Verifica
+
+```bash
+curl -sf <APP_URL>/api/v1/health        # backend via nginx → 200
+curl -sf <APP_URL>/auth/realms/rstmanager/.well-known/openid-configuration | jq .issuer
+#   deve stampare esattamente "<AUTH_URL>/realms/rstmanager"
+```
+
+Poi apri `<APP_URL>`, fai login: il redirect a Keycloak e il ritorno con token
+devono funzionare same-origin.
+
+## Troubleshooting
+
+| Sintomo | Causa probabile |
+|---------|-----------------|
+| nginx 502 su `/api` o `/auth` | Backend/Keycloak non bindano `::` (IPv6), o upstream senza suffisso `.railway.internal` |
+| 401 su tutte le `/api/v1/*` | `RSTMANAGER_KEYCLOAK_ISSUER` ≠ issuer reale del token; controlla che `KC_HOSTNAME` = `<AUTH_URL>` |
+| Redirect di login su `localhost:3333` | `RSTMANAGER_PUBLIC_APP_URL` non impostata **al primo import** del realm; aggiornala e ri-crea il realm (o correggi il client nell'admin console — l'import salta se il realm esiste già) |
+| Keycloak "insecure"/mixed content | Manca `KC_PROXY_HEADERS=xforwarded`; nginx già inoltra `X-Forwarded-Proto` reale |
+| nginx non risolve gli upstream | Il resolver viene letto da `/etc/resolv.conf` all'avvio; su Railway è IPv6 e lo script forza `ipv6=on` — se cambi immagine base verifica che resolv.conf sia presente |
+| Cambio dominio pubblico | Aggiorna `KC_HOSTNAME`, `RSTMANAGER_PUBLIC_APP_URL`, `RSTMANAGER_KEYCLOAK_ISSUER` e i redirect URIs del client Keycloak |
+
+## Costi/note
+
+Keycloak è il servizio più pesante (deve stare sempre acceso, ~500 MB RAM, DB
+dedicato). Se in futuro vuoi alleggerire, valuta un IdP gestito, ma richiede di
+ricablare issuer/JWKS del backend.

--- a/nginx.frontend.conf.template
+++ b/nginx.frontend.conf.template
@@ -1,0 +1,81 @@
+# Rendered at container start by the official nginx template mechanism
+# (/etc/nginx/templates/*.template -> /etc/nginx/conf.d/*.conf via envsubst).
+# Only ${RSTMANAGER_*} placeholders are substituted (NGINX_ENVSUBST_FILTER),
+# so nginx runtime variables like $host or $scheme are left untouched.
+#
+# Values are populated by docker-entrypoint.d/10-rstmanager-resolver.envsh:
+#   RSTMANAGER_NGINX_PORT           listen port ($PORT on Railway, 80 in compose)
+#   RSTMANAGER_API_UPSTREAM         planning-service host:port
+#   RSTMANAGER_KC_UPSTREAM          keycloak host:port
+#   RSTMANAGER_NGINX_RESOLVER       DNS resolver from /etc/resolv.conf
+#   RSTMANAGER_NGINX_RESOLVER_IPV6  ipv6=on (Railway) / ipv6=off (Docker DNS)
+
+# Honour the edge-terminated TLS scheme: Railway (and any reverse proxy in
+# front) forwards the real scheme in X-Forwarded-Proto; fall back to the
+# connection scheme when the header is absent (e.g. local compose over http).
+map $http_x_forwarded_proto $rstmanager_fwd_proto {
+  default $scheme;
+  ""      $scheme;
+  https   https;
+  http    http;
+}
+
+server {
+  listen ${RSTMANAGER_NGINX_PORT};
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  resolver ${RSTMANAGER_NGINX_RESOLVER} valid=10s ${RSTMANAGER_NGINX_RESOLVER_IPV6};
+  set $rstmanager_api ${RSTMANAGER_API_UPSTREAM};
+  set $rstmanager_kc ${RSTMANAGER_KC_UPSTREAM};
+
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $rstmanager_fwd_proto;
+
+  location = /api {
+    proxy_pass http://$rstmanager_api;
+  }
+
+  location /api/ {
+    proxy_pass http://$rstmanager_api;
+  }
+
+  location = /auth {
+    proxy_pass http://$rstmanager_kc;
+  }
+
+  location /auth/ {
+    proxy_pass http://$rstmanager_kc;
+    # The Keycloak admin console sends large headers/cookies.
+    proxy_buffer_size 16k;
+    proxy_buffers 8 16k;
+  }
+
+  location = /docs {
+    proxy_pass http://$rstmanager_api;
+  }
+
+  location /docs/ {
+    proxy_pass http://$rstmanager_api;
+  }
+
+  location = /index.html {
+    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+    try_files /index.html =404;
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location / {
+    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/railway.frontend.json
+++ b/railway.frontend.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.frontend"
+  },
+  "deploy": {
+    "healthcheckPath": "/",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.keycloak.json
+++ b/railway.keycloak.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.keycloak"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.service.json
+++ b/railway.service.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.service"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/v1/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
Map the compose stack onto Railway (one service per image, IPv6-only private networking, managed Postgres) while preserving the same-origin design where nginx is the single public entrypoint proxying /api, /auth and /docs.

- nginx.frontend.conf.template + docker/nginx entrypoint: render port, upstreams and the DNS resolver at start, distinguishing Docker (IPv4, ipv6=off) from Railway (IPv6-only *.railway.internal, ipv6=on), and forward the real X-Forwarded-Proto behind the TLS-terminating edge.
- Dockerfile.keycloak + entrypoint: bake the realm and rewrite the public origin at start (bash builtins only), reusing the committed realm file.
- railway.{service,frontend,keycloak}.json: per-service config-as-code.
- docs/DEPLOY-railway.md: topology, per-service env tables, bring-up order, verification and troubleshooting (incl. the IPv6 bind gotcha).

No Scala changes: the frontend is already same-origin and the backend reads DB/Keycloak config and its bind host from env (:: on Railway). Local docker compose is behaviour-preserving (port 80, short upstreams, 127.0.0.11 resolver).
