### PR TITLE
fix(deploy): build optimized Keycloak image to avoid start-time OOM

### DIFF
--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -1,6 +1,21 @@
 ARG KEYCLOAK_IMAGE=quay.io/keycloak/keycloak:26.3
 
+# Build (augmentation) stage: bake the build-time options into an optimized
+# distribution. Augmentation is memory-hungry and, when left to run at container
+# start, peaks close to the runtime memory ceiling on small Railway instances
+# (and was OOM-killed at the 512MB default). Doing it here means runtime uses
+# `start --optimized` and skips augmentation entirely.
+FROM ${KEYCLOAK_IMAGE} AS builder
+
+ENV KC_DB=postgres
+ENV KC_HEALTH_ENABLED=true
+ENV KC_HTTP_RELATIVE_PATH=/auth
+
+RUN /opt/keycloak/bin/kc.sh build
+
 FROM ${KEYCLOAK_IMAGE}
+
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
 # The realm is baked into the image (Railway has no bind mounts). It lives in a
 # template dir; the entrypoint rewrites the public origin into the import dir at
@@ -13,4 +28,5 @@ RUN chmod +x /opt/keycloak/rstmanager-entrypoint.sh
 USER 1000
 
 ENTRYPOINT ["/opt/keycloak/rstmanager-entrypoint.sh"]
-CMD ["start", "--import-realm"]
+# --optimized: skip the start-time build step (already done in the builder).
+CMD ["start", "--optimized", "--import-realm"]

--- a/docs/DEPLOY-railway.md
+++ b/docs/DEPLOY-railway.md
@@ -138,6 +138,15 @@ backend.
    / webOrigins del client nel realm importato. **Non** dare un dominio pubblico
    a questo servizio: resta privato.
 
+   > **Immagine optimized:** `Dockerfile.keycloak` esegue `kc.sh build` a build
+   > time bakando le opzioni **build-time** `KC_DB=postgres`,
+   > `KC_HEALTH_ENABLED=true`, `KC_HTTP_RELATIVE_PATH=/auth`, e a runtime lancia
+   > `start --optimized`. Così l'augmentation Quarkus non gira all'avvio (era la
+   > causa dell'OOM `Killed` sul default da 512MB, e resta vicina al tetto anche
+   > a 1GB). Le tre variabili qui sopra restano impostate con gli **stessi
+   > valori** — combaciano col build, nessun warning; se un domani ne cambi una,
+   > serve rifare il build dell'immagine.
+
 ### 5. Servizio `planning-service`
 
 1. **New → GitHub Repo** → nome `planning-service`.
@@ -198,6 +207,7 @@ devono funzionare same-origin.
 | Keycloak "insecure"/mixed content | Manca `KC_PROXY_HEADERS=xforwarded`; nginx già inoltra `X-Forwarded-Proto` reale |
 | nginx non risolve gli upstream | Il resolver viene letto da `/etc/resolv.conf` all'avvio; su Railway è IPv6 e lo script forza `ipv6=on` — se cambi immagine base verifica che resolv.conf sia presente |
 | Cambio dominio pubblico | Aggiorna `KC_HOSTNAME`, `RSTMANAGER_PUBLIC_APP_URL`, `RSTMANAGER_KEYCLOAK_ISSUER` e i redirect URIs del client Keycloak |
+| Keycloak `Killed` in avvio (OOM sullo step `build-and-exit`) | `Dockerfile.keycloak` fa `kc.sh build` a build time e `start --optimized` a runtime, così l'augmentation non gira all'avvio. Se persiste, aumenta la RAM del servizio Keycloak su Railway |
 
 ## Costi/note
 


### PR DESCRIPTION
`kc.sh start` runs a Quarkus augmentation (build-and-exit) step on every start unless the image is optimized; that step is memory-hungry and gets OOM-killed on small Railway instances (Killed / signal 9 at the 512MB default, and stays close to the ceiling even at 1GB). Move the build into a builder stage (kc.sh build with KC_DB / KC_HEALTH_ENABLED / KC_HTTP_RELATIVE_PATH baked) and run `start --optimized --import-realm` at runtime so no augmentation happens at start.